### PR TITLE
Fix assess function not tracking draws properly

### DIFF
--- a/assessment/assessor.py
+++ b/assessment/assessor.py
@@ -26,7 +26,7 @@ def assess(student_strategy):
 
         if result[0] == 1:
             wins += 1
-        elif result[0] == 0:
+        elif result[0] == -1:
             draws += 1
         elif result[1]:
             forfeits += 1

--- a/game/victory_check.py
+++ b/game/victory_check.py
@@ -101,7 +101,7 @@ def check_draw(board):
 def check_victory(board):
     '''Checks an entire board for any type of victory
     (param) board ([[int]*6]*7): A board
-    (return) Will be 0 for no win, 1 for player 1 win, or 2 for player 2 win'''
+    (return) Will be 0 for no win, 1 for player 1 win, 2 for player 2 win, or -1 for a draw'''
     victory = check_vertical_victory(board)
     if victory:
         return victory


### PR DESCRIPTION
Draws are currently tracked as losses in the `assess` function. `check_victory` returns -1 for a draw, not 0.